### PR TITLE
fix: remove hard exits and refactor to return errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ func main() {
     options.Env = "production"
     options.Tags = "logging,golang"
 
-    myLogger := logger.CreateLogger(options, key)
+    myLogger, err := logger.CreateLogger(options, key)
 }
 ```
 _**Required**_
@@ -58,14 +58,14 @@ func main() {
 
     // Can also use Go's short-hand syntax for initializing structs to define all your options in just a single line:
     options := logger.Options{Level: "error", Hostname: "gotest", App: "myapp", IPAddress: "10.0.1.101", MacAddress: "C0:FF:EE:C0:FF:EE"}
-    myLogger := logger.CreateLogger(options, key)
+    myLogger, err := logger.CreateLogger(options, key)
 
     myLogger.Log("Message 2")
 
     // Configure options, level and app with specific logs
     newOptions := logger.Options{Level: "warning", Hostname: "gotest", App: "myotherapp", IPAddress: "10.0.1.101", MacAddress:  "C0:FF:EE:C0:FF:EE"}
-    myLogger.LogWithOptions("Message 3", newOptions)
-    myLogger.LogWithLevelAndApp("Message 4", "fatal", "gotest2")
+    errWithOpts := myLogger.LogWithOptions("Message 3", newOptions)
+    errLevelAndApp := myLogger.LogWithLevelAndApp("Message 4", "fatal", "gotest2")
     myLogger.Close()
 }
 ```
@@ -91,7 +91,7 @@ func main() {
 
     options.Meta = meta
 
-    myLogger := logger.CreateLogger(options, key)
+    myLogger, err := logger.CreateLogger(options, key)
 
     myLogger.Log("Message 7")
     myLogger.Close()

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -3,14 +3,18 @@ package logger
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"regexp"
+	"strings"
 	"time"
+
 	"github.com/joho/godotenv"
 )
+
+var defaultIngestURL = "https://logs.logdna.com/logs/ingest"
 
 // Options encapsulates user-provided options such as the Level and App
 // that are passed along with each log.
@@ -51,14 +55,39 @@ type Message struct {
 	Options Options
 }
 
-func checkParameterLength(optionsType string, parameter string) {
-	if len(parameter) > 32 {
-		fmt.Println(optionsType + " length must be less than 32!")
-		os.Exit(3)
-	}
+// InvalidOptionMessage represents an issue with the supplied configuration.
+type InvalidOptionMessage struct {
+	Option  string
+	Message string
 }
 
-func checkOptions(options *Options) {
+func (e InvalidOptionMessage) String() string {
+	return fmt.Sprintf("Options.%s: %s", e.Option, e.Message)
+}
+
+func (options *Options) validate() error {
+	var problems []string
+	reMacAddress := regexp.MustCompile(`^([0-9a-fA-F][0-9a-fA-F]:){5}([0-9a-fA-F][0-9a-fA-F])`)
+	reHostname := regexp.MustCompile(`(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])`)
+	reIPAddress := regexp.MustCompile(`(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}`)
+
+	validateOptionLength("App", options.App, &problems)
+	validateOptionLength("Env", options.Env, &problems)
+	validateOptionLength("Hostname", options.Hostname, &problems)
+	validateOptionLength("Level", options.Level, &problems)
+
+	if options.MacAddress != "" && (!reMacAddress.MatchString(options.MacAddress)) {
+		problems = append(problems, InvalidOptionMessage{"MacAddress", "invalid format"}.String())
+	}
+
+	if options.Hostname != "" && !reHostname.MatchString(options.Hostname) {
+		problems = append(problems, InvalidOptionMessage{"Hostname", "invalid format"}.String())
+	}
+
+	if options.IPAddress != "" && !reIPAddress.MatchString(options.IPAddress) {
+		problems = append(problems, InvalidOptionMessage{"IPAddress", "invalid format"}.String())
+	}
+
 	if options.FlushInterval == 0 {
 		options.FlushInterval = 5 * time.Second
 	}
@@ -66,29 +95,19 @@ func checkOptions(options *Options) {
 		options.MaxBufferLen = 5
 	}
 	if options.IngestURL == "" {
-		options.IngestURL = "https://logs.logdna.com/logs/ingest"
+		options.IngestURL = defaultIngestURL
 	}
 
-	checkParameterLength("App", options.App)
-	checkParameterLength("Env", options.Env)
-	checkParameterLength("Hostname", options.Hostname)
-	checkParameterLength("Level", options.Level)
-
-	reMacAddress := regexp.MustCompile(`^([0-9a-fA-F][0-9a-fA-F]:){5}([0-9a-fA-F][0-9a-fA-F])`)
-	reHostname := regexp.MustCompile(`(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])`)
-	reIPAddress := regexp.MustCompile(`(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}`)
-
-	if options.MacAddress != "" && (!reMacAddress.MatchString(options.MacAddress)) {
-		fmt.Println("Invalid MAC Address format.")
-		os.Exit(3)
+	if len(problems) > 0 {
+		return errors.New(strings.Join(problems, ", "))
 	}
-	if options.Hostname != "" && !reHostname.MatchString(options.Hostname) {
-		fmt.Println("Invalid hostname.")
-		os.Exit(3)
-	}
-	if options.IPAddress != "" && !reIPAddress.MatchString(options.IPAddress) {
-		fmt.Println("Invalid IP Address format.")
-		os.Exit(3)
+
+	return nil
+}
+
+func validateOptionLength(option string, value string, problems *[]string) {
+	if len(value) > 32 {
+		*problems = append(*problems, InvalidOptionMessage{option, "length must be less than 32"}.String())
 	}
 }
 
@@ -123,9 +142,12 @@ func (logger *Logger) processRequest() {
 
 // CreateLogger creates a logger with parametrized options and key.
 // This logger can then be used to send logs into LogDNA.
-func CreateLogger(options Options, key string) *Logger {
+func CreateLogger(options Options, key string) (*Logger, error) {
 	godotenv.Load(".env")
-	checkOptions(&options)
+	err := options.validate()
+	if err != nil {
+		return nil, err
+	}
 
 	logger := Logger{
 		Key:      key,
@@ -133,7 +155,7 @@ func CreateLogger(options Options, key string) *Logger {
 		Options:  options,
 	}
 	go logger.processRequest()
-	return &logger
+	return &logger, nil
 }
 
 // Log sends a provided log message to LogDNA.
@@ -145,15 +167,20 @@ func (logger *Logger) Log(message string) {
 }
 
 // LogWithLevel sends a log message to LogDNA with a parametrized level.
-func (logger *Logger) LogWithLevel(message string, level string) {
-	checkParameterLength("Level", level)
+func (logger *Logger) LogWithLevel(message string, level string) error {
+	options := Options{Level: level}
+	err := options.validate()
+	if err != nil {
+		return err
+	}
 
 	loggerMessage := Message{
 		Body:  message,
-		Level: level,
+		Level: options.Level,
 	}
 
 	logger.Messages <- loggerMessage
+	return nil
 }
 
 // Info logs a message at level Info to LogDNA.
@@ -188,8 +215,11 @@ func (logger *Logger) Critical(message string) {
 
 // LogWithOptions allows the user to update options uniquely for a given log message
 // before sending the log to LogDNA.
-func (logger *Logger) LogWithOptions(message string, options Options) {
-	checkOptions(&options)
+func (logger *Logger) LogWithOptions(message string, options Options) error {
+	err := options.validate()
+	if err != nil {
+		return err
+	}
 
 	loggerMessage := Message{
 		Body:    message,
@@ -197,24 +227,29 @@ func (logger *Logger) LogWithOptions(message string, options Options) {
 	}
 
 	logger.Messages <- loggerMessage
+	return nil
 }
 
 // LogWithLevelAndApp allows the user to customize level and app uniquely for a single log
 // before sending the log into LogDNA.
-func (logger *Logger) LogWithLevelAndApp(message string, level string, app string) {
-	checkParameterLength("Level", level)
-	checkParameterLength("App", app)
+func (logger *Logger) LogWithLevelAndApp(message string, level string, app string) error {
+	options := Options{Level: level, App: app}
+	err := options.validate()
+	if err != nil {
+		return err
+	}
 
 	loggerMessage := Message{
 		Body:  message,
-		Level: level,
-		App:   app,
+		Level: options.Level,
+		App:   options.App,
 	}
 
 	logger.Messages <- loggerMessage
+	return nil
 }
 
-func (logger Logger) makeRequest(logmsg Message) {
+func (logger Logger) makeRequest(logmsg Message) error {
 	var arr [1]map[string]interface{}
 	var level string
 	var app string
@@ -270,9 +305,9 @@ func (logger Logger) makeRequest(logmsg Message) {
 
 	bytesRepresentation, err := json.Marshal(message)
 	if err != nil {
-		log.Fatalln(err)
+		return err
 	}
-	
+
 	req, err := http.NewRequest("POST", options.IngestURL, bytes.NewBuffer(bytesRepresentation))
 	req.Header.Set("user-agent", os.Getenv("USERAGENT"))
 	req.Header.Set("apikey", logger.Key)
@@ -282,15 +317,16 @@ func (logger Logger) makeRequest(logmsg Message) {
 	resp, err := client.Do(req)
 
 	if err != nil {
-		log.Fatalln(err)
+		return err
 	}
 
 	defer resp.Body.Close()
 
 	var result map[string]interface{}
-
 	json.NewDecoder(resp.Body).Decode(&result)
 	if err != nil {
-		log.Fatalln(err)
+		return err
 	}
+
+	return nil
 }

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -26,7 +26,11 @@ func TestMeta(t *testing.T) {
 		IndexMeta:  true,
 	}
 
-	myLogger := CreateLogger(options, key)
+	myLogger, err := CreateLogger(options, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	myLogger.Log("Message 1")
 	myLogger.Close()
 }
@@ -43,7 +47,11 @@ func TestBufferLen(t *testing.T) {
 		MaxBufferLen: 10,
 	}
 
-	myLogger := CreateLogger(options, key)
+	myLogger, err := CreateLogger(options, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	myLogger.Log("Message 1")
 	myLogger.Close()
 }
@@ -60,12 +68,16 @@ func TestFlushInterval(t *testing.T) {
 		FlushInterval: 10 * time.Second,
 	}
 
-	myLogger := CreateLogger(options, key)
+	myLogger, err := CreateLogger(options, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	myLogger.Log("Message 1")
 	myLogger.Close()
 }
 
-func TestLongLevel(t *testing.T) {
+func TestInvalidLevelLength(t *testing.T) {
 	options := Options{}
 	options.Level = "fatalfatalfatalfatalfatalfatalfatalfatalfatalfatalfatalfatalfatal"
 	options.Hostname = "gotest"
@@ -75,27 +87,29 @@ func TestLongLevel(t *testing.T) {
 	options.Env = "production"
 	options.Tags = "logging,golang"
 
-	myLogger := CreateLogger(options, key)
-	myLogger.Log("Message 1")
-	myLogger.Close()
+	_, err := CreateLogger(options, key)
+	if err == nil {
+		t.Fatal("Error expected but not returned")
+	}
 }
 
-func TestLongApp(t *testing.T) {
+func TestInvalidAppLength(t *testing.T) {
 	options := Options{}
 	options.Level = "fatal"
 	options.Hostname = "gotest"
 	options.App = "myappmyappmyappmyappmyappmyappmyappmyappmyappmyapp"
 	options.IPAddress = "10.0.1.101"
 	options.MacAddress = "C0:FF:EE:C0:FF:EE"
-	options.Env = "productionproductionproductionproductionproductionproductionproduction"
+	options.Env = "production"
 	options.Tags = "logging,golang"
 
-	myLogger := CreateLogger(options, key)
-	myLogger.Log("Message 1")
-	myLogger.Close()
+	_, err := CreateLogger(options, key)
+	if err == nil {
+		t.Fatal("Error expected but not returned")
+	}
 }
 
-func TestLongEnv(t *testing.T) {
+func TestInvalidEnvLength(t *testing.T) {
 	meta := Meta{}
 	nestedMeta := Meta{}
 	nestedMeta.Value = "nested field"
@@ -113,12 +127,13 @@ func TestLongEnv(t *testing.T) {
 	options.Meta = meta
 	options.IndexMeta = true
 
-	myLogger := CreateLogger(options, key)
-	myLogger.Log("Message 1")
-	myLogger.Close()
+	_, err := CreateLogger(options, key)
+	if err == nil {
+		t.Fatal("Error expected but not returned")
+	}
 }
 
-func TestLongHostname(t *testing.T) {
+func TestInvalidHostnameLength(t *testing.T) {
 	meta := Meta{}
 	nestedMeta := Meta{}
 	nestedMeta.Value = "nested field"
@@ -136,9 +151,10 @@ func TestLongHostname(t *testing.T) {
 	options.Meta = meta
 	options.IndexMeta = true
 
-	myLogger := CreateLogger(options, key)
-	myLogger.Log("Message 1")
-	myLogger.Close()
+	_, err := CreateLogger(options, key)
+	if err == nil {
+		t.Fatal("Error expected but not returned")
+	}
 }
 
 func TestInvalidMac(t *testing.T) {
@@ -159,9 +175,10 @@ func TestInvalidMac(t *testing.T) {
 	options.Meta = meta
 	options.IndexMeta = true
 
-	myLogger := CreateLogger(options, key)
-	myLogger.Log("Message 1")
-	myLogger.Close()
+	_, err := CreateLogger(options, key)
+	if err == nil {
+		t.Fatal("Error expected but not returned")
+	}
 }
 
 func TestInvalidIp(t *testing.T) {
@@ -182,14 +199,19 @@ func TestInvalidIp(t *testing.T) {
 	options.Meta = meta
 	options.IndexMeta = true
 
-	myLogger := CreateLogger(options, key)
-	myLogger.Log("Message 1")
-	myLogger.Close()
+	_, err := CreateLogger(options, key)
+	if err == nil {
+		t.Fatal("Error expected but not returned")
+	}
 }
 
 func TestLevels(t *testing.T) {
 	options := Options{Level: "error", Hostname: "gotest", App: "myapp", IPAddress: "10.0.1.101", MacAddress: "C0:FF:EE:C0:FF:EE"}
-	myLogger := CreateLogger(options, key)
+	myLogger, err := CreateLogger(options, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	myLogger.Info("Message 1")
 	myLogger.Warn("Message 2")
 	myLogger.Debug("Message 3")
@@ -201,20 +223,35 @@ func TestLevels(t *testing.T) {
 
 func TestLogWithOptions(t *testing.T) {
 	options := Options{Level: "error", Hostname: "gotest", App: "myapp", IPAddress: "10.0.1.101", MacAddress: "C0:FF:EE:C0:FF:EE"}
-	myLogger := CreateLogger(options, key)
+	myLogger, err := CreateLogger(options, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	otherOptions := Options{Level: "warning", Hostname: "gotest2", App: "myapp", IPAddress: "10.0.1.101", MacAddress: "C0:FF:EE:C0:FF:EE"}
 	myLogger.Log("Message 1")
-	myLogger.LogWithOptions("Message 2", otherOptions)
+	err = myLogger.LogWithOptions("Message 2", otherOptions)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	myLogger.Log("Message 3")
 	myLogger.Close()
-
 }
 
 func TestLogWithLevelAndApp(t *testing.T) {
 	options := Options{Level: "warning", Hostname: "gotest", App: "myapp"}
-	myLogger := CreateLogger(options, key)
+	myLogger, err := CreateLogger(options, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	myLogger.Log("Message 1")
-	myLogger.LogWithLevelAndApp("Message 2", "error", "gotest2")
+	err = myLogger.LogWithLevelAndApp("Message 2", "error", "gotest2")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	myLogger.Log("Message 3")
 	myLogger.Close()
 }
@@ -236,7 +273,11 @@ func TestMultipleLoggers(t *testing.T) {
 		Tags:       "logging,golang",
 	}
 
-	myLogger := CreateLogger(options, key)
+	myLogger, err := CreateLogger(options, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	myLogger.Log("Message 1")
 	myLogger.Info("Message 2")
 	myLogger.Debug("Message 3")
@@ -250,11 +291,18 @@ func TestMultipleLoggers(t *testing.T) {
 		IPAddress:  "10.0.1.101",
 		MacAddress: "C0:FF:EE:C0:FF:EE",
 	}
-	myLogger2 := CreateLogger(options2, key)
-	myLogger2.LogWithOptions("Message 1", options)
+	myLogger2, err := CreateLogger(options2, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = myLogger2.LogWithOptions("Message 1", options)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	myLogger2.Log("Message 2")
 	myLogger2.Log("Message 3")
 	myLogger2.Log("Message 4")
 	myLogger2.Close()
-
 }

--- a/test.go
+++ b/test.go
@@ -21,7 +21,11 @@ func main() {
 	options.Env = "production"
 	options.Tags = "logging,golang"
 
-	myLogger := logger.CreateLogger(options, key)
+	myLogger, err := logger.CreateLogger(options, key)
+	if err != nil {
+		panic(err)
+	}
+
 	myLogger.Log("Message 1")
 	myLogger.Info("Message 2")
 	myLogger.Debug("Message 3")
@@ -35,16 +39,32 @@ func main() {
 	myLogger.Close()
 
 	options2 := logger.Options{Level: "error", Hostname: "gotest2", App: "myapp", IPAddress: "10.0.1.101", MacAddress: "C0:FF:EE:C0:FF:EE"}
-	myLogger2 := logger.CreateLogger(options2, key)
+	myLogger2, err := logger.CreateLogger(options2, key)
+	if err != nil {
+		panic(err)
+	}
+
 	myLogger2.Log("Message 1")
-	myLogger2.LogWithOptions("Message 2", options)
+	err = myLogger2.LogWithOptions("Message 2", options)
+	if err != nil {
+		panic(err)
+	}
+
 	myLogger2.Log("Message 3")
 	myLogger2.Close()
 
 	options3 := logger.Options{Level: "warning", Hostname: "gotest3", App: "myapp"}
-	myLogger3 := logger.CreateLogger(options3, key)
+	myLogger3, err := logger.CreateLogger(options3, key)
+	if err != nil {
+		panic(err)
+	}
+
 	myLogger3.Log("Message 1")
-	myLogger3.LogWithLevelAndApp("Message 2", "error", "gotest2")
+	err = myLogger3.LogWithLevelAndApp("Message 2", "error", "gotest2")
+	if err != nil {
+		panic(err)
+	}
+
 	myLogger3.Log("Message 3")
 	myLogger3.Close()
 }


### PR DESCRIPTION
BREAKING CHANGE:
* remove all os.Exit() and log.Fatalln()
* functions/methods that accept options now return errors
  when validation fails
* validation moved to a method on Options
    
Semver: major
Ref: LOG-6963