### PR TITLE
refactor!: batch logs and periodically flush buffer

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,30 +1,25 @@
 package logger
 
 import (
-	"bytes"
 	"encoding/json"
-	"net/http"
-	"os"
-	"time"
 
 	"github.com/joho/godotenv"
 )
 
 // Logger is the means by which a user can begin to send logs.
 type Logger struct {
-	Buffer   []Message
-	Key      string
-	Messages chan Message
-	Options  Options
+	Options Options
+
+	transport *transport
 }
 
-// Message encapsulates app, level, message and options data.
+// Message represents a single log message and associated options.
 type Message struct {
 	Body    string
 	Options Options
 }
 
-// Payload contains the properties sent to the ingestion endpoint
+// Payload contains the properties sent to the ingestion endpoint.
 type Payload struct {
 	APIKey     string `json:"apikey,omitempty"`
 	Hostname   string `json:"hostname,omitempty"`
@@ -34,7 +29,7 @@ type Payload struct {
 	Lines      []Line `json:"lines,omitempty"`
 }
 
-// Line contains properties related to an individual log message
+// Line contains properties related to an individual log message.
 type Line struct {
 	App   string       `json:"app,omitempty"`
 	Body  string       `json:"line,omitempty"`
@@ -43,29 +38,29 @@ type Line struct {
 	Meta  metaEnvelope `json:"meta,omitempty"`
 }
 
+type ingestAPIResponse struct {
+	status  string
+	batchID string
+	code    string
+	error   string
+}
+
 type metaEnvelope struct {
-	Indexed bool
-	Meta    string
+	indexed bool
+	meta    string
 }
 
 func (me metaEnvelope) MarshalJSON() ([]byte, error) {
-	if !me.Indexed {
-		return json.Marshal(me.Meta)
+	if !me.indexed {
+		return json.Marshal(me.meta)
 	}
 
-	return []byte(me.Meta), nil
+	return []byte(me.meta), nil
 }
 
-// Close must be run after a user is done with using a logger before logs are viewable within LogDNA.
-func (logger *Logger) Close() {
-	time.Sleep(logger.Options.FlushInterval)
-	logger.flush()
-	close(logger.Messages)
-}
-
-// CreateLogger creates a logger with parametrized options and key.
+// NewLogger creates a logger with parametrized options and key.
 // This logger can then be used to send logs into LogDNA.
-func CreateLogger(options Options, key string) (*Logger, error) {
+func NewLogger(options Options, key string) (*Logger, error) {
 	godotenv.Load(".env")
 	err := options.validate()
 	if err != nil {
@@ -74,148 +69,77 @@ func CreateLogger(options Options, key string) (*Logger, error) {
 
 	options.setDefaults()
 	logger := Logger{
-		Key:      key,
-		Messages: make(chan Message),
-		Options:  options,
+		Options:   options,
+		transport: newTransport(options, key),
 	}
-	go logger.handleMessages()
+
 	return &logger, nil
 }
 
+// Close must be called when finished logging to ensure all buffered logs are sent
+func (l *Logger) Close() {
+	l.transport.close()
+}
+
 // Log sends a provided log message to LogDNA.
-func (logger *Logger) Log(message string) {
-	loggerMessage := Message{
+func (l *Logger) Log(message string) {
+	logMsg := Message{
 		Body:    message,
-		Options: logger.Options,
+		Options: l.Options,
 	}
-	logger.Messages <- loggerMessage
+	l.transport.add(logMsg)
 }
 
 // LogWithOptions allows the user to update options uniquely for a given log message
 // before sending the log to LogDNA.
-func (logger *Logger) LogWithOptions(message string, options Options) error {
-	msgopts := logger.Options.merge(options)
-	err := msgopts.validate()
+func (l *Logger) LogWithOptions(message string, options Options) error {
+	msgOpts := l.Options.merge(options)
+	err := msgOpts.validate()
 	if err != nil {
 		return err
 	}
 
-	loggerMessage := Message{
+	logMsg := Message{
 		Body:    message,
-		Options: msgopts,
+		Options: msgOpts,
 	}
 
-	logger.Messages <- loggerMessage
+	l.transport.add(logMsg)
 	return nil
 }
 
 // LogWithLevel sends a log message to LogDNA with a parameterized level.
-func (logger *Logger) LogWithLevel(message string, level string) error {
+func (l *Logger) LogWithLevel(message string, level string) error {
 	options := Options{Level: level}
-	return logger.LogWithOptions(message, options)
+	return l.LogWithOptions(message, options)
 }
 
 // Info logs a message at level Info to LogDNA.
-func (logger *Logger) Info(message string) {
-	logger.LogWithLevel(message, "info")
+func (l *Logger) Info(message string) {
+	l.LogWithLevel(message, "info")
 }
 
 // Warn logs a message at level Warn to LogDNA.
-func (logger *Logger) Warn(message string) {
-	logger.LogWithLevel(message, "warn")
+func (l *Logger) Warn(message string) {
+	l.LogWithLevel(message, "warn")
 }
 
 // Debug logs a message at level Debug to LogDNA.
-func (logger *Logger) Debug(message string) {
-	logger.LogWithLevel(message, "debug")
+func (l *Logger) Debug(message string) {
+	l.LogWithLevel(message, "debug")
 }
 
 // Error logs a message at level Error to LogDNA.
-func (logger *Logger) Error(message string) {
-	logger.LogWithLevel(message, "error")
+func (l *Logger) Error(message string) {
+	l.LogWithLevel(message, "error")
 }
 
 // Fatal logs a message at level Fatal to LogDNA.
-func (logger *Logger) Fatal(message string) {
-	logger.LogWithLevel(message, "fatal")
+func (l *Logger) Fatal(message string) {
+	l.LogWithLevel(message, "fatal")
 }
 
 // Critical logs a message at level Critical to LogDNA.
-func (logger *Logger) Critical(message string) {
-	logger.LogWithLevel(message, "critical")
-}
-
-func (logger *Logger) handleMessages() {
-	for msg := range logger.Messages {
-		logger.Buffer = append(logger.Buffer, msg)
-		logger.checkBuffer()
-	}
-}
-
-func (logger *Logger) checkBuffer() {
-	length := len(logger.Buffer)
-	if length >= logger.Options.MaxBufferLen {
-		logger.flush()
-	}
-}
-
-func (logger *Logger) flush() {
-	length := len(logger.Buffer)
-	for i := 0; i < length; i++ {
-		logger.send(logger.Buffer[i])
-	}
-	logger.Buffer = logger.Buffer[:0]
-}
-
-func (logger Logger) send(msg Message) error {
-	line := Line{
-		Body:  msg.Body,
-		App:   msg.Options.App,
-		Env:   msg.Options.Env,
-		Level: msg.Options.Level,
-	}
-
-	if msg.Options.Meta != "" {
-		line.Meta = metaEnvelope{
-			Indexed: msg.Options.IndexMeta,
-			Meta:    msg.Options.Meta,
-		}
-	}
-
-	lines := []Line{line}
-	payload := Payload{
-		APIKey:     logger.Key,
-		Hostname:   msg.Options.Hostname,
-		IPAddress:  msg.Options.IPAddress,
-		MacAddress: msg.Options.MacAddress,
-		Tags:       msg.Options.Tags,
-		Lines:      lines,
-	}
-
-	pbytes, err := json.Marshal(payload)
-	if err != nil {
-		return err
-	}
-
-	req, err := http.NewRequest("POST", msg.Options.IngestURL, bytes.NewBuffer(pbytes))
-	req.Header.Set("user-agent", os.Getenv("USERAGENT"))
-	req.Header.Set("apikey", logger.Key)
-	req.Header.Set("Content-type", "application/json")
-
-	client := &http.Client{}
-	resp, err := client.Do(req)
-
-	if err != nil {
-		return err
-	}
-
-	defer resp.Body.Close()
-
-	var result map[string]interface{}
-	err = json.NewDecoder(resp.Body).Decode(&result)
-	if err != nil {
-		return err
-	}
-
-	return nil
+func (l *Logger) Critical(message string) {
+	l.LogWithLevel(message, "critical")
 }

--- a/logger/options.go
+++ b/logger/options.go
@@ -8,7 +8,12 @@ import (
 	"time"
 )
 
-var defaultIngestURL = "https://logs.logdna.com/logs/ingest"
+var (
+	defaultIngestURL     = "https://logs.logdna.com/logs/ingest"
+	defaultSendTimeout   = 5 * time.Second
+	defaultFlushInterval = 250 * time.Millisecond
+	defaultMaxBufferLen  = 50
+)
 
 // InvalidOptionMessage represents an issue with the supplied configuration.
 type InvalidOptionMessage struct {
@@ -22,6 +27,7 @@ type Options struct {
 	App           string
 	Env           string
 	FlushInterval time.Duration
+	SendTimeout   time.Duration
 	Hostname      string
 	IndexMeta     bool
 	IngestURL     string
@@ -92,11 +98,14 @@ func (options Options) merge(merge Options) Options {
 }
 
 func (options *Options) setDefaults() {
+	if options.SendTimeout == 0 {
+		options.SendTimeout = defaultSendTimeout
+	}
 	if options.FlushInterval == 0 {
-		options.FlushInterval = 5 * time.Second
+		options.FlushInterval = defaultFlushInterval
 	}
 	if options.MaxBufferLen == 0 {
-		options.MaxBufferLen = 5
+		options.MaxBufferLen = defaultMaxBufferLen
 	}
 	if options.IngestURL == "" {
 		options.IngestURL = defaultIngestURL

--- a/logger/options_test.go
+++ b/logger/options_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestOptions_validate(t *testing.T) {
+func TestOptions_Validate(t *testing.T) {
 	testCases := []struct {
 		label   string
 		options Options
@@ -37,7 +37,7 @@ func TestOptions_validate(t *testing.T) {
 	}
 }
 
-func TestOptions_merge(t *testing.T) {
+func TestOptions_Merge(t *testing.T) {
 	o := Options{
 		App:   "app",
 		Env:   "development",
@@ -58,15 +58,16 @@ func TestOptions_merge(t *testing.T) {
 	assert.Equal(t, `{"baz": "merge"}`, o.Meta)
 }
 
-func TestOptions_setDefaults(t *testing.T) {
+func TestOptions_SetDefaults(t *testing.T) {
 	t.Run("Sets defaults", func(t *testing.T) {
 		o := Options{}
 		err := o.validate()
 		assert.Equal(t, nil, err)
 
 		o.setDefaults()
-		assert.Equal(t, 5*time.Second, o.FlushInterval)
-		assert.Equal(t, 5, o.MaxBufferLen)
+		assert.Equal(t, defaultSendTimeout, o.SendTimeout)
+		assert.Equal(t, defaultFlushInterval, o.FlushInterval)
+		assert.Equal(t, defaultMaxBufferLen, o.MaxBufferLen)
 		assert.Equal(t, defaultIngestURL, o.IngestURL)
 	})
 
@@ -76,6 +77,8 @@ func TestOptions_setDefaults(t *testing.T) {
 		assert.Equal(t, nil, err)
 
 		o.setDefaults()
+
+		assert.Equal(t, defaultSendTimeout, o.SendTimeout)
 		assert.Equal(t, 10*time.Second, o.FlushInterval)
 		assert.Equal(t, 10, o.MaxBufferLen)
 		assert.Equal(t, "https://example.org", o.IngestURL)

--- a/logger/transport.go
+++ b/logger/transport.go
@@ -1,0 +1,151 @@
+package logger
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+)
+
+type transport struct {
+	key     string
+	buffer  []Message
+	options Options
+	done    chan struct{}
+
+	mu sync.Mutex
+	wg sync.WaitGroup
+}
+
+func newTransport(options Options, key string) *transport {
+	t := transport{
+		key:     key,
+		options: options,
+		done:    make(chan struct{}),
+	}
+
+	go t.flushInterval()
+
+	return &t
+}
+
+func (t *transport) close() {
+	t.flush()
+
+	close(t.done)
+	t.wg.Wait()
+}
+
+func (t *transport) add(msg Message) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.buffer = append(t.buffer, msg)
+
+	if len(t.buffer) >= t.options.MaxBufferLen {
+		t.flushSend()
+	}
+}
+
+func (t *transport) flush() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.flushSend()
+}
+
+func (t *transport) flushInterval() {
+	ticker := time.NewTicker(t.options.FlushInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			t.flush()
+		case <-t.done:
+			return
+		}
+	}
+}
+
+func (t *transport) flushSend() {
+	msgs := t.buffer
+	t.buffer = t.buffer[:0]
+
+	if len(msgs) == 0 {
+		return
+	}
+
+	t.wg.Add(1)
+	go func() {
+		// TODO(mdeltito): in the future a retry should be triggered
+		// with the msgs pulled out of the buffer
+		t.send(msgs)
+		t.wg.Done()
+	}()
+}
+
+func (t *transport) send(msgs []Message) error {
+	var lines []Line
+	for _, msg := range msgs {
+		line := Line{
+			Body:  msg.Body,
+			App:   msg.Options.App,
+			Env:   msg.Options.Env,
+			Level: msg.Options.Level,
+		}
+
+		if msg.Options.Meta != "" {
+			line.Meta = metaEnvelope{
+				indexed: msg.Options.IndexMeta,
+				meta:    msg.Options.Meta,
+			}
+		}
+
+		lines = append(lines, line)
+	}
+
+	payload := Payload{
+		APIKey:     t.key,
+		Hostname:   t.options.Hostname,
+		IPAddress:  t.options.IPAddress,
+		MacAddress: t.options.MacAddress,
+		Tags:       t.options.Tags,
+		Lines:      lines,
+	}
+
+	pbytes, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("POST", t.options.IngestURL, bytes.NewBuffer(pbytes))
+	req.Header.Set("user-agent", os.Getenv("USERAGENT"))
+	req.Header.Set("apikey", t.key)
+	req.Header.Set("Content-type", "application/json")
+
+	client := &http.Client{Timeout: t.options.SendTimeout}
+	resp, err := client.Do(req)
+
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 500 {
+		return fmt.Errorf("Server error: %d", resp.StatusCode)
+	}
+
+	// TODO(mdeltito): do we need to parse the response?
+	// we arent doing anything with it
+	var apiresp ingestAPIResponse
+	err = json.NewDecoder(resp.Body).Decode(&apiresp)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
BREAKING CHANGE:
* rename CreateLogger to NewLogger to better align with best practice
* break out transport code and reimplement FlushInterval
  * logs are now flushed periodically - new default is 250ms
  * logs are also async flushed when hitting the MaxBufferLen
  * maxBufferLen default increased to 50
* logs are now batched when sending, up to MaxBufferLen
* add a configurable SendTimeout, default of 5 seconds

Semver: major
Ref: LOG-6965