### PR TITLE
improvement: Rework options validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ For more information on testing see: https://golang.org/pkg/testing/
 
 ## API
 
-### CreateLogger(Options, Key)
+### NewLogger(Options, Key)
 ---
 
 #### Options
@@ -115,9 +115,9 @@ For more information on testing see: https://golang.org/pkg/testing/
 * Type: `string`
 * Default: `''`
 * Example Values: `YourCustomApp`
-* Max Length: `32`
+* Max Length: `80`
 
-The default app passed along with every log sent through this instance.
+Arbitrary app name for labeling each message.
 
 ##### Env
 
@@ -125,18 +125,18 @@ The default app passed along with every log sent through this instance.
 * Type: `string`
 * Default: `''`
 * Example Values: `YourCustomEnvironment`
-* Max Length: `32`
+* Max Length: `80`
 
-The default environment passed along with every log sent through this instance.
+An environment label attached to each message.
 
 ##### FlushInterval
 
 * _**Optional**_
 * Type: `time.duration`
-* Default: `5 * time.Second`
+* Default: `250 * time.Millisecond`
 * Example Values: `10 * time.Second`
 
-The flush interval sets how often data is flushed and logs are shipped into LogDNA.
+Time to wait before sending the buffer.
 
 ##### Hostname
 
@@ -144,9 +144,9 @@ The flush interval sets how often data is flushed and logs are shipped into LogD
 * Type: `string`
 * Default: `''`
 * Example Values: `YourCustomHostname`
-* Max Length: `32`
+* Max Length: `80`
 
-The default hostname passed along with every log sent through this instance.
+Hostname for each HTTP request.
 
 ##### IndexMeta
 
@@ -155,11 +155,7 @@ The default hostname passed along with every log sent through this instance.
 * Default: `false`
 * Example Values: `true`
 
-We allow meta objects to be passed with each line. By default these meta objects will be stringified and will not be searchable, but will be displayed for informational purposes.
-
-If this option is set to true then meta objects will be parsed and will be searchable up to three levels deep. Any fields deeper than three levels will be stringified and cannot be searched.
-
-WARNING When this option is true, your metadata objects across all types of log messages MUST have consistent types or the metadata object may not be parsed properly!
+Controls whether meta data for each message is searchable.
 
 ##### IngestURL
 
@@ -167,7 +163,7 @@ WARNING When this option is true, your metadata objects across all types of log 
 * Type: `string`
 * Default: `https://logs.logdna.com/logs/ingest`
 
-A custom ingestion endpoint to stream log lines into.
+URL of the logging server.
 
 ##### IPAddress
 
@@ -176,7 +172,7 @@ A custom ingestion endpoint to stream log lines into.
 * Default: `''`
 * Example Values: `10.0.0.1`
 
-The default IP Address passed along with every log sent through this instance.
+IPv4 or IPv6 address for each HTTP request.
 
 ##### Level
 
@@ -184,34 +180,43 @@ The default IP Address passed along with every log sent through this instance.
 * Type: `string`
 * Default: `Info`
 * Example Values: `Debug`, `Trace`, `Info`, `Warn`, `Error`, `Fatal`, `YourCustomLevel`
-* Max Length: `32`
+* Max Length: `80`
 
-The default level passed along with every log sent through this instance.
+Level to be used if not specified elsewhere.
 
 ##### MacAddress
 
 * _**Optional**_
 * Type: `string`
 * Default: `''`
-* Example Values: `C0:FF:EE:C0:FF:EE`
+* Example Values: `c0:ff:ee:c0:ff:ee`
 
-The default MAC Address passed along with every log sent through this instance.
+MAC address for each HTTP request.
 
 ##### MaxBufferLen
 
 * _**Optional**_
 * Type: `int`
-* Default: `5`
+* Default: `50`
 * Example Values: `10`
 
-MaxBufferLen sets the number of logs that are buffered before data is flushed and shipped to LogDNA.
+Maximum total line lengths before a flush is forced.
 
 ##### Meta
 
 * _**Optional**_
 * Type: `string`
 
-A JSON string containing additional metadata about the log line that is passed.
+Global metadata. Added to each message, unless overridden.
+
+##### SendTimeout
+
+* _**Optional**_
+* Type: `time.Duration`
+* Default: `30 * time.Second`
+* Example Values: `10`
+
+Time limit in seconds to wait for each HTTP request before timing out.
 
 ##### Tags
 
@@ -220,16 +225,16 @@ A JSON string containing additional metadata about the log line that is passed.
 * Default: `5`
 * Example Values: `logging,golang`
 
+Tags to be added to each message.
 
-List of tags used to dynamically group hosts.
+#### Timestamp
 
-#### Key
+* _**Optional**_
+* Type: `time.Time`
+* Default Values: `time.Now()`
+* Example Values: `time.Now()`
 
-* _**Required**_
-* Type: `string`
-* Example Values: `123abc`
-
-The [LogDNA Ingestion Key](https://app.logdna.com/manage/profile) associated with your account.
+Epoch ms time to use if not provided elsewhere.
 
 ---
 
@@ -240,7 +245,7 @@ The [LogDNA Ingestion Key](https://app.logdna.com/manage/profile) associated wit
 * Type: `string`
 * Default: `''`
 
-The line/message to be sent to the LogDNA system.
+Text of the log entry.
 
 ---
 
@@ -252,7 +257,7 @@ The line/message to be sent to the LogDNA system.
 * Type: `string`
 * Default: `''`
 
-The line/message to be sent to the LogDNA system.
+Text of the log entry.
 
 #### Options
 
@@ -262,9 +267,9 @@ The line/message to be sent to the LogDNA system.
 * Type: `string`
 * Default: `''`
 * Example Values: `YourCustomApp`
-* Max Length: `32`
+* Max Length: `80`
 
-The default app passed along with every log sent through this instance.
+App name to use for the current message.
 
 ##### Env
 
@@ -272,18 +277,18 @@ The default app passed along with every log sent through this instance.
 * Type: `string`
 * Default: `''`
 * Example Values: `YourCustomEnvironment`
-* Max Length: `32`
+* Max Length: `80`
 
-The default environment passed along with every log sent through this instance.
+Environment name to use for the current message.
 
 ##### FlushInterval
 
 * _**Optional**_
 * Type: `time.duration`
-* Default: `5`
-* Example Values: `YourCustomEnvironment`
+* Default: `250 * time.Millisecond`
+* Example Values: `10 * time.Second`
 
-The flush interval sets how often data is flushed and logs shipped into LogDNA.
+Time to wait before sending the buffer.
 
 ##### Hostname
 
@@ -291,9 +296,9 @@ The flush interval sets how often data is flushed and logs shipped into LogDNA.
 * Type: `string`
 * Default: `''`
 * Example Values: `YourCustomHostname`
-* Max Length: `32`
+* Max Length: `80`
 
-The default hostname passed along with every log sent through this instance.
+Hostname to use for the current message.
 
 ##### IndexMeta
 
@@ -302,11 +307,7 @@ The default hostname passed along with every log sent through this instance.
 * Default: `false`
 * Example Values: `true`
 
-We allow meta objects to be passed with each line. By default these meta objects will be stringified and will not be searchable, but will be displayed for informational purposes.
-
-If this option is turned to true then meta objects will be parsed and will be searchable up to three levels deep. Any fields deeper than three levels will be stringified and cannot be searched.
-
-WARNING When this option is true, your metadata objects across all types of log messages MUST have consistent types or the metadata object may not be parsed properly!
+Allows for the meta to be searchable in LogDNA.
 
 ##### IngestURL
 
@@ -314,7 +315,7 @@ WARNING When this option is true, your metadata objects across all types of log 
 * Type: `string`
 * Default: `https://logs.logdna.com/logs/ingest`
 
-A custom ingestion endpoint to stream log lines into.
+URL of the logging server.
 
 ##### IPAddress
 
@@ -323,7 +324,7 @@ A custom ingestion endpoint to stream log lines into.
 * Default: `''`
 * Example Values: `10.0.0.1`
 
-The default IP Address passed along with every log sent through this instance.
+IPv4 or IPv6 address for the current message.
 
 ##### Level
 
@@ -331,34 +332,43 @@ The default IP Address passed along with every log sent through this instance.
 * Type: `string`
 * Default: `Info`
 * Example Values: `Debug`, `Trace`, `Info`, `Warn`, `Error`, `Fatal`, `YourCustomLevel`
-* Max Length: `32`
+* Max Length: `80`
 
-The default level passed along with every log sent through this instance.
+Desired level for the current message. 
 
 ##### MacAddress
 
 * _**Optional**_
 * Type: `string`
 * Default: `''`
-* Example Values: `C0:FF:EE:C0:FF:EE`
+* Example Values: `c0:ff:ee:c0:ff:ee`
 
-The default MAC Address passed along with every log sent through this instance.
+MAC address for the current message.
 
 ##### MaxBufferLen
 
 * _**Optional**_
 * Type: `int`
-* Default: `5`
+* Default: `50`
 * Example Values: `10`
 
-MaxBufferLen sets the number of logs that are buffered before data is flushed and shipped to LogDNA.
+Maximum total line lengths before a flush is forced.
 
 ##### Meta
 
 * _**Optional**_
-* Type: `Meta`
+* Type: `string`
 
-A meta object for additional metadata about the log line that is passed.
+Per-message meta data. 
+
+##### SendTimeout
+
+* _**Optional**_
+* Type: `time.Duration`
+* Default: `30 * time.Second`
+* Example Values: `10`
+
+Time limit in seconds to wait before timing out.
 
 ##### Tags
 
@@ -367,8 +377,16 @@ A meta object for additional metadata about the log line that is passed.
 * Default: `5`
 * Example Values: `logging,golang`
 
+Tags to be added for the current message.
 
-List of tags used to dynamically group hosts.
+#### Timestamp
+
+* _**Optional**_
+* Type: `time.Time`
+* Default Values: `time.Now()`
+* Example Values: `time.Now()`
+
+Epoch ms time to use for the current message.
 
 ---
 
@@ -380,7 +398,7 @@ List of tags used to dynamically group hosts.
 * Type: `string`
 * Default: `''`
 
-The line which will be sent to the LogDNA system.
+Text of the log entry.
 
 #### Level
 
@@ -388,9 +406,9 @@ The line which will be sent to the LogDNA system.
 * Type: `string`
 * Default: ``
 * Example Values: `Debug`, `Trace`, `Info`, `Warn`, `Error`, `Fatal`, `YourCustomLevel`
-* Max Length: `32`
+* Max Length: `80`
 
-The default level passed along with every log sent through this instance.
+Desired level for the current message.
 
 ---
 

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -34,7 +34,7 @@ func TestLogger_NewLogger(t *testing.T) {
 
 	t.Run("Invalid options", func(t *testing.T) {
 		o := Options{
-			Level: strings.Repeat("a", 33),
+			Level: strings.Repeat("a", 83),
 		}
 
 		_, err := NewLogger(o, "abc123")
@@ -71,7 +71,7 @@ func TestLogger_Log(t *testing.T) {
 	assert.Equal(t, "abc123", body["apikey"])
 	assert.Equal(t, "foo", body["hostname"])
 	assert.Equal(t, "127.0.0.1", body["ip"])
-	assert.Equal(t, "C0:FF:EE:C0:FF:EE", body["mac"])
+	assert.Equal(t, "c0:ff:ee:c0:ff:ee", body["mac"])
 	assert.NotEmpty(t, body["lines"])
 
 	ls := body["lines"].([]interface{})
@@ -126,6 +126,7 @@ func TestLogger_LogWithOptions(t *testing.T) {
 		assert.Equal(t, "production", line["env"])
 		assert.Equal(t, "error", line["level"])
 		assert.Equal(t, now.UnixNano()/int64(time.Millisecond), int64(line["timestamp"].(float64)))
+
 	})
 
 	t.Run("Invalid options", func(t *testing.T) {
@@ -139,7 +140,7 @@ func TestLogger_LogWithOptions(t *testing.T) {
 		assert.Equal(t, nil, err)
 
 		err = l.LogWithOptions("testing", Options{
-			App: strings.Repeat("a", 33),
+			App: strings.Repeat("a", 83),
 		})
 
 		assert.Error(t, err)

--- a/logger/options_test.go
+++ b/logger/options_test.go
@@ -12,26 +12,27 @@ func TestOptions_Validate(t *testing.T) {
 	testCases := []struct {
 		label   string
 		options Options
-		valid   bool
+		errStr  string
 	}{
-		{"Base case", Options{}, true},
-		{"With options", Options{Level: "error", Hostname: "foo", App: "app", IPAddress: "127.0.0.1", MacAddress: "C0:FF:EE:C0:FF:EE"}, true},
-		{"App length", Options{App: strings.Repeat("a", 33)}, false},
-		{"Env length", Options{Env: strings.Repeat("a", 33)}, false},
-		{"Hostname length", Options{Hostname: strings.Repeat("a", 33)}, false},
-		{"Level length", Options{Level: strings.Repeat("a", 33)}, false},
-		{"Invalid MacAddress", Options{MacAddress: "in:va:lid"}, false},
-		{"Invalid Hostname", Options{Hostname: "-"}, false},
-		{"Invalid IPAddress", Options{IPAddress: "localhost"}, false},
+		{"Base case", Options{}, ""},
+		{"With options", Options{Level: "error", Hostname: "foo", App: "app", IPAddress: "127.0.0.1", MacAddress: "C0:FF:EE:C0:FF:EE"}, ""},
+		{"App length", Options{App: strings.Repeat("a", 83)}, "One or more invalid options:\nApp: length must be less than 80\n"},
+		{"Env length", Options{Env: strings.Repeat("a", 83)}, "One or more invalid options:\nEnv: length must be less than 80\n"},
+		{"Hostname length", Options{Hostname: strings.Repeat("a", 83)}, "One or more invalid options:\nHostname: length must be less than 80\n"},
+		{"Level length", Options{Level: strings.Repeat("a", 83)}, "One or more invalid options:\nLevel: length must be less than 80\n"},
+		{"Invalid MacAddress", Options{MacAddress: "in:va:lid"}, "One or more invalid options:\nMacAddress: Invalid format\n"},
+		{"Invalid Hostname", Options{Hostname: "-"}, "One or more invalid options:\nHostname: Invalid format\n"},
+		{"Invalid IPAddress", Options{IPAddress: "localhost"}, "One or more invalid options:\nIPAddress: Invalid format\n"},
+		{"Invalid MacAddress, Hostname and IPAddress", Options{MacAddress: "in:va:lid", Hostname: "-", IPAddress: "localhost"}, "One or more invalid options:\nMacAddress: Invalid format\nHostname: Invalid format\nIPAddress: Invalid format\n"},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.label, func(t *testing.T) {
 			err := tc.options.validate()
-			if tc.valid {
+			if tc.errStr == "" {
 				assert.Equal(t, nil, err)
 			} else {
-				assert.Error(t, err)
+				assert.EqualError(t, err, tc.errStr)
 			}
 		})
 	}

--- a/logger/transport.go
+++ b/logger/transport.go
@@ -145,8 +145,6 @@ func (t *transport) send(msgs []Message) error {
 		return fmt.Errorf("Server error: %d", resp.StatusCode)
 	}
 
-	// TODO(mdeltito): do we need to parse the response?
-	// we arent doing anything with it
 	var apiresp ingestAPIResponse
 	err = json.NewDecoder(resp.Body).Decode(&apiresp)
 	if err != nil {


### PR DESCRIPTION
**improvement: Rework options validation**

Rework validation for MAC and IP addresses to use net. Also updates max length to 80, the hostname regex, the README and reworks error handling.

Semver: Patch
Ref: LOG-6969