### PR TITLE
fix: increase default send timeout

### DIFF
--- a/logger/options.go
+++ b/logger/options.go
@@ -8,9 +8,9 @@ import (
 	"time"
 )
 
-var (
+const (
 	defaultIngestURL     = "https://logs.logdna.com/logs/ingest"
-	defaultSendTimeout   = 5 * time.Second
+	defaultSendTimeout   = 30 * time.Second
 	defaultFlushInterval = 250 * time.Millisecond
 	defaultMaxBufferLen  = 50
 )


### PR DESCRIPTION
We have seen reports in other clients that this timout can be too
short. Increase this to 30 seconds by default.

Semver: patch
Ref: LOG-7279